### PR TITLE
improve handling ${workspace_loc} to allow usage of environment variable

### DIFF
--- a/src/com/kukido/eclipser/configuration/ConfigurationBuilder.java
+++ b/src/com/kukido/eclipser/configuration/ConfigurationBuilder.java
@@ -8,6 +8,8 @@ import com.intellij.psi.xml.XmlTag;
 import com.kukido.eclipser.EclipserException;
 import com.kukido.eclipser.EclipserXml;
 
+import java.util.regex.Matcher;
+
 public class ConfigurationBuilder {
 
     private PsiFile psiFile;
@@ -125,14 +127,18 @@ public class ConfigurationBuilder {
     }
 
     private String convertWorkspace(String value) {
-        return value.replace("}", "").replace("${workspace_loc:", ExternalToolConfiguration.PROJECT_FILE_DIR);
+        return replaceWorkspaceLoc(value, ExternalToolConfiguration.PROJECT_FILE_DIR);
+    }
+
+    private String replaceWorkspaceLoc(String value, String basePath) {
+        return value.replaceAll("\\$\\{workspace_loc:([^\\}]*)\\}", Matcher.quoteReplacement(basePath) + "$1");
     }
 
     private String resolveToProjectLocation(String value) {
         if (value.contains(EclipserXml.PROJECT_LOC)) {
             return value.replace("${project_loc}", psiFile.getProject().getBasePath());
         } else if (value.contains(EclipserXml.WORKSPACE_LOC)) {
-            return value.replace("${workspace_loc:", psiFile.getProject().getBasePath()).replace("}", "");
+            return replaceWorkspaceLoc(value, psiFile.getProject().getBasePath());
         } else {
             return value;
         }

--- a/test/com/kukido/eclipser/configuration/ConfigurationBuilderTest.java
+++ b/test/com/kukido/eclipser/configuration/ConfigurationBuilderTest.java
@@ -69,7 +69,7 @@ public class ConfigurationBuilderTest extends LightIdeaTestCase {
         assertEquals("com.thimbleware.jmemcached.Main", jc.getMainClassName());
         assertEquals("jmemcached-server", jc.getModuleName());
         assertEquals(JavaConfiguration.MODULE_DIR_MACRO, jc.getWorkingDirectory());
-        assertEquals("--memory 10M --port 11111", jc.getProgramParameters());
+        assertEquals("--memory 10M --port 11111 --env ${ENV}", jc.getProgramParameters());
     }
 
 	public void testJavaConfigurationWithControlCharacters() throws Exception {

--- a/test/resources/arguments.launch
+++ b/test/resources/arguments.launch
@@ -8,6 +8,6 @@
         <listEntry value="1"/>
     </listAttribute>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.thimbleware.jmemcached.Main"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="--memory 10M --port 11111"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="--memory 10M --port 11111 --env ${ENV}"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="jmemcached-server"/>
 </launchConfiguration>


### PR DESCRIPTION
at the moment there is a bug that is visible if in configuration there are environment variable like ${ENV} and it is replaced by ${ENV 
It solves the issue by using regular expression replace instead of string based one.
