### PR TITLE
Support new lines with Program Arguments

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -72,7 +72,6 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <fileTypeFactory implementation="com.kukido.eclipser.EclipserFileTypeFactory"/>
-        <configurationType implementation="com.kukido.eclipser.EclipserConfigurationType"/>
         <syntaxHighlighter key="Eclipser" implementationClass="com.intellij.ide.highlighter.XmlFileHighlighter"/>
     </extensions>
 </idea-plugin>

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -22,6 +22,8 @@
 
     <change-notes><![CDATA[
         <dl>
+            <dt>0.6.1</dt>
+            <dd>- support for escaped characters (i.e. new lines in particular) with program arguments</dd>
             <dt>0.6</dt>
             <dd>- support for Ant launch configuration [experimental]</dd>
             <dd>- support for Remote Java application configuration [experimental]</dd>

--- a/src/com/kukido/eclipser/configuration/ConfigurationBuilder.java
+++ b/src/com/kukido/eclipser/configuration/ConfigurationBuilder.java
@@ -66,7 +66,7 @@ public class ConfigurationBuilder {
                     } else if (EclipserXml.ATTR_TOOL_ARGUMENTS_KEY.equalsIgnoreCase(key)) {
                         parameters = convertWorkspace(value);
                     } else if (EclipserXml.PROGRAM_ARGUMENTS_KEY.equalsIgnoreCase(key)) {
-                        programArguments = value;
+                        programArguments = normalizeText(value);
                     } else if (EclipserXml.ATTR_WORKING_DIRECTORY_KEY.equalsIgnoreCase(key)) {
                         attrWorkingDirectory = convertWorkspace(value);
                     } else if (EclipserXml.M2_PROFILES_KEY.equalsIgnoreCase(key)) {

--- a/test/com/kukido/eclipser/configuration/ConfigurationBuilderTest.java
+++ b/test/com/kukido/eclipser/configuration/ConfigurationBuilderTest.java
@@ -95,6 +95,22 @@ public class ConfigurationBuilderTest extends LightIdeaTestCase {
         assertEquals("--memory 10M --port 11111 --env ${ENV}", jc.getProgramParameters());
     }
 
+    public void testJavaConfigurationWithArgumentsIncludingNewLine() throws Exception {
+        PsiFile file = getPsiFile("arguments-withnewline.launch");
+        builder = new ConfigurationBuilder(file);
+        Configuration conf = builder.build();
+
+        assertInstanceOf(conf, JavaConfiguration.class);
+
+        JavaConfiguration jc = (JavaConfiguration)conf;
+
+        assertEquals("arguments-withnewline", jc.getConfigurationName());
+        assertEquals("com.thimbleware.jmemcached.Main", jc.getMainClassName());
+        assertEquals("jmemcached-server", jc.getModuleName());
+        assertEquals(JavaConfiguration.MODULE_DIR_MACRO, jc.getWorkingDirectory());
+        assertEquals(String.format("--memory 10M%n--port 11111 --env ${ENV}"), jc.getProgramParameters());
+    }
+
 	public void testJavaConfigurationWithControlCharacters() throws Exception {
 		PsiFile file = getPsiFile("newline.launch");
 		builder = new ConfigurationBuilder(file);

--- a/test/resources/arguments-withnewline.launch
+++ b/test/resources/arguments-withnewline.launch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+    <stringAttribute key="bad_container_name" value="\dbAccessLayer\launcher"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/jmemcached-server/source/com/thimbleware/jmemcached/Main.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="com.thimbleware.jmemcached.Main"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="--memory 10M&#13;&#10;--port 11111 --env ${ENV}"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="jmemcached-server"/>
+</launchConfiguration>


### PR DESCRIPTION
All the unit tests fail because a class is referenced which does not exist anymore.  I have fixed that by removing the reference - it must be redundant.

More importantly, I have added a change (and a new support unit test, and updated the changes notes) which allows for normalisation of text within the PROGRAM_ARGUMENTS as well VM_ARGUMENTS

Thanks
Donald