### PR TITLE
Add support for $env_var macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Eclipser will automatically convert Eclipse launch configurations into IntelliJ 
   * Context menu for supported launch files will contain "Convert with Eclipser" item.
 
 ## Functionality limitations:
-  * Current support for one Eclipse macro only: 
+  * Current support for two Eclipse macros only:
     - $workspace_loc
+    - $env_var
   * Eclipse UI launch configuration is not supported:
     - org.eclipse.pde.ui.RuntimeWorkbench
 

--- a/src/com/kukido/eclipser/EclipserXml.java
+++ b/src/com/kukido/eclipser/EclipserXml.java
@@ -45,5 +45,6 @@ public interface EclipserXml {
     // eclipse macros
     @NonNls String WORKSPACE_LOC    = "workspace_loc";
     @NonNls String PROJECT_LOC      = "project_loc";
+    @NonNls String ENV_VAR          = "env_var";
 
 }

--- a/src/com/kukido/eclipser/configuration/ConfigurationBuilder.java
+++ b/src/com/kukido/eclipser/configuration/ConfigurationBuilder.java
@@ -115,7 +115,7 @@ public class ConfigurationBuilder {
 
     private Configuration createConfiguration(String configurationType) throws EclipserException {
         if (EclipserXml.CONFIGURATION_TYPE_LOCAL_JAVA_APPLICATION.equalsIgnoreCase(configurationType)) {
-            return new JavaConfiguration(name, mainType, moduleName, vmParameters, programArguments, environmentVariables, resolveToProjectLocation(workingDirectory));
+            return new JavaConfiguration(name, mainType, moduleName, convertEnvVarMacro(vmParameters), convertEnvVarMacro(programArguments), environmentVariables, resolveToProjectLocation(workingDirectory));
         } else if (EclipserXml.CONFIGURATION_TYPE_PROGRAM_LAUNCH.equalsIgnoreCase(configurationType)) {
             return new ExternalToolConfiguration(name, convertWorkspace(location), parameters, attrWorkingDirectory);
         } else if (EclipserXml.CONFIGURATION_TYPE_MAVEN2_LAUNCH.equalsIgnoreCase(configurationType)) {
@@ -127,6 +127,13 @@ public class ConfigurationBuilder {
         } else {
             throw new EclipserException("Unsupported configuration type: " + configurationType);
         }
+    }
+    
+    private String convertEnvVarMacro(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace(EclipserXml.ENV_VAR + ":", "");
     }
 
     private String normalizeText(String value) {

--- a/test/com/kukido/eclipser/configuration/ConfigurationBuilderTest.java
+++ b/test/com/kukido/eclipser/configuration/ConfigurationBuilderTest.java
@@ -45,7 +45,7 @@ public class ConfigurationBuilderTest extends LightIdeaTestCase {
         assertEquals("Main", jc.getMainClassName());
         assertEquals("simple", jc.getModuleName());
         assertEquals(JavaConfiguration.MODULE_DIR_MACRO, jc.getWorkingDirectory());
-        assertEquals("-Duser=${USER}", jc.getVmParameters());
+        assertEquals("-Duser=${USER} -Dhost.fqdn=${COMPUTERNAME}.domain.local", jc.getVmParameters());
         Map<String, String> expectedEnv = new LinkedHashMap<String, String>();
         expectedEnv.put("ENV","TEST");
         assertEquals(expectedEnv, jc.getEnvironmentVariables());

--- a/test/resources/env.launch
+++ b/test/resources/env.launch
@@ -14,5 +14,5 @@
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="Main"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="simple"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Duser=${USER}"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Duser=${USER} -Dhost.fqdn=${env_var:COMPUTERNAME}.domain.local"/>
 </launchConfiguration>


### PR DESCRIPTION
Eclipse launch targets allow the use of (native) environment variables in VM and program arguments. IntelliJ supports this as well, but uses a slightly different syntax.

```
eclipse : -Dhost.fqdn=${env_var:COMPUTERNAME}.domain.local
intellij: -Dhost.fqdn=${COMPUTERNAME}.domain.local
```

This change adds support the ${env_var:} syntax.